### PR TITLE
bump update timer to one year

### DIFF
--- a/src/cryptonote_basic/hardfork.h
+++ b/src/cryptonote_basic/hardfork.h
@@ -46,7 +46,7 @@ namespace cryptonote
 
     static const uint64_t DEFAULT_ORIGINAL_VERSION_TILL_HEIGHT = 0; // <= actual height
     static const time_t DEFAULT_FORKED_TIME = 31557600; // a year in seconds
-    static const time_t DEFAULT_UPDATE_TIME = 31557600 / 2;
+    static const time_t DEFAULT_UPDATE_TIME = 31557600; // a year in seconds
     static const uint64_t DEFAULT_WINDOW_SIZE = 10080; // supermajority window check length - a week
     static const uint8_t DEFAULT_THRESHOLD_PERCENT = 80;
 


### PR DESCRIPTION
 - addresses issue #125
 - confirmed that "status" command no longer shows "update needed"