### PR TITLE
Avoid run directory being removed by cleaning scripts

### DIFF
--- a/debian/lethean-daemon.postinst
+++ b/debian/lethean-daemon.postinst
@@ -19,6 +19,7 @@ if [ "$1" = "configure" ]; then
     chmod 770 /var/lib/lthn
     chown lthn:lthn /var/run/lthn -R
     chmod 770 /var/run/lthn
+    touch /var/run/lthn/.keep
 fi
 
 # dh_installdeb will replace this with shell code automatically


### PR DESCRIPTION
https://github.com/LetheanMovement/lethean-vpn/issues/102

not sure it's the best possible fix, but it should work.
maybe there's a more standard way to do it.